### PR TITLE
build: loosen `jscodeshift` peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "jscodeshift-find-imports": "^2.0.2"
   },
   "peerDependencies": {
-    "jscodeshift": "^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0"
+    "jscodeshift": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -112,6 +112,6 @@
     "jscodeshift-find-imports": "^2.0.2"
   },
   "peerDependencies": {
-    "jscodeshift": "^0.7.0"
+    "jscodeshift": ">=0.7 <1"
   }
 }


### PR DESCRIPTION
With this plugin being stale and `jscodeshift` moving forward too strict peer dependency on `jscodeshift` becomes apparent. 🙈 
Installing this plugin with the latest `jscodeshift` results in the following warning:
<img width="757" alt="Screenshot 2024-07-03 at 16 08 40" src="https://github.com/codemodsquad/jscodeshift-add-imports/assets/4941090/302923db-3d57-4c59-9732-d27d60aec5db">
